### PR TITLE
Get rid of junk prepared statement creation from device brand method

### DIFF
--- a/src/main/java/org/udger/parser/UdgerParser.java
+++ b/src/main/java/org/udger/parser/UdgerParser.java
@@ -521,7 +521,11 @@ public class UdgerParser implements Closeable {
     }
 
     private void fetchDeviceBrand(String uaString, UdgerUaResult ret) throws SQLException {
-        PreparedStatement preparedStatement = connection.prepareStatement(UdgerSqlQuery.SQL_DEVICE_REGEX);
+        PreparedStatement preparedStatement = preparedStmtMap.get(UdgerSqlQuery.SQL_DEVICE_REGEX);
+        if (preparedStatement == null) {
+            preparedStatement = connection.prepareStatement(UdgerSqlQuery.SQL_DEVICE_REGEX);
+            preparedStmtMap.put(UdgerSqlQuery.SQL_DEVICE_REGEX, preparedStatement);
+        }
         preparedStatement.setObject(1, ret.getOsFamilyCode());
         preparedStatement.setObject(2, ret.getOsCode());
         ResultSet devRegexRs  = preparedStatement.executeQuery();


### PR DESCRIPTION
@skybber I think this is a good fix and will get rid of unnecessary prepared statements thereby further prevent memory leak and reduce garbage collection cycles. 