### PR TITLE
Update Maven dependency version number to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Example:
 <dependency>
     <groupId>org.udger.parser</groupId>
     <artifactId>udger-parser</artifactId>
-    <version>1.0.5</version>
+    <version>1.1.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
The maven dependency suggested in README defines version number 1.0.5 whereas the newest version in Maven is 1.1.1

The documentation in this README doesn't work with 1.0.5 anymore as there's no UdgerParser.ParserDbData in the old release.