### PR TITLE
Make ParserDbData thread safe

### DIFF
--- a/src/main/java/org/udger/parser/UdgerParser.java
+++ b/src/main/java/org/udger/parser/UdgerParser.java
@@ -49,16 +49,18 @@ public class UdgerParser implements Closeable {
         private List<IdRegString> osRegstringList;
         private List<IdRegString> deviceRegstringList;
 
-        private String dbFileName;
+        private volatile boolean prepared = false;
+
+        private final String dbFileName;
 
         public ParserDbData(String dbFileName) {
             this.dbFileName = dbFileName;
         }
 
         protected void prepare(Connection connection) throws SQLException {
-            if (clientRegstringList == null) {
+            if (!prepared) {
                 synchronized (this) {
-                    if (clientRegstringList == null) {
+                    if (!prepared) {
                         clientRegstringList = prepareRegexpStruct(connection, "udger_client_regex");
                         osRegstringList = prepareRegexpStruct(connection, "udger_os_regex");
                         deviceRegstringList = prepareRegexpStruct(connection, "udger_deviceclass_regex");
@@ -66,6 +68,7 @@ public class UdgerParser implements Closeable {
                         clientWordDetector = createWordDetector(connection, "udger_client_regex", "udger_client_regex_words");
                         deviceWordDetector = createWordDetector(connection, "udger_deviceclass_regex", "udger_deviceclass_regex_words");
                         osWordDetector = createWordDetector(connection, "udger_os_regex", "udger_os_regex_words");
+                        prepared = true;
                     }
                 }
             }

--- a/src/test/java/org/udger/parser/UdgerParserTest.java
+++ b/src/test/java/org/udger/parser/UdgerParserTest.java
@@ -1,11 +1,14 @@
 package org.udger.parser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.sql.SQLException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
 
 import org.junit.After;
 import org.junit.Before;
@@ -15,11 +18,12 @@ public class UdgerParserTest {
 
     private UdgerParser parser;
     private UdgerParser inMemoryParser;
+    private UdgerParser.ParserDbData parserDbData;
 
     @Before
     public void initialize() throws SQLException {
         URL resource = this.getClass().getClassLoader().getResource("udgerdb_test_v3.dat");
-        UdgerParser.ParserDbData parserDbData = new UdgerParser.ParserDbData(resource.getFile());
+        parserDbData = new UdgerParser.ParserDbData(resource.getFile());
         parser = new UdgerParser(parserDbData);
         inMemoryParser = new UdgerParser(parserDbData, true, 0); // no cache
     }
@@ -59,5 +63,48 @@ public class UdgerParserTest {
         String ipQuery = "108.61.199.93";
         UdgerIpResult qr = inMemoryParser.parseIp(ipQuery);
         assertEquals(qr.getIpClassificationCode(), "crawler");
+    }
+
+    @Test
+    public void testParserDbDataThreadSafety() throws Throwable {
+        final int numThreads = 500;
+        final String uaQuery = "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0";
+
+        final CyclicBarrier gate = new CyclicBarrier(numThreads);
+        final ConcurrentLinkedQueue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+        Thread[] threads = new Thread[numThreads];
+        for (int i = 0; i < numThreads; i++) {
+            threads[i] = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    UdgerParser threadParser = new UdgerParser(parserDbData);
+                    try {
+                        gate.await();
+                        for (int j = 0; j < 100; j++) {
+                            UdgerUaResult qr = threadParser.parseUa(uaQuery);
+                            assertEquals(qr.getUa(), "Firefox 40.0");
+                            assertEquals(qr.getOs(), "Windows 10");
+                            assertEquals(qr.getUaFamily(), "Firefox");
+                        }
+                    } catch (Throwable t) {
+                        failures.add(t);
+                    }
+                }
+            });
+            threads[i].start();
+        }
+
+        for (int i = 0; i < numThreads; i++) {
+            threads[i].join();
+        }
+
+        if (!failures.isEmpty()) {
+            for (Throwable throwable : failures) {
+                throwable.printStackTrace();
+            }
+
+            fail("Parsing threads failed, see printed exceptions");
+        }
     }
 }


### PR DESCRIPTION
It looks like the intention of `ParserDbData` is that a single instance can be shared by a number of `UdgerParser`s, potentially each used by a different thread. However, while the ParserDbData fields are written under lock, they are not read under the same lock. That can result in some of those writes not being immediately visible to a other threads.

This results in exceptions like 

```
java.lang.NullPointerException
	at org.udger.parser.UdgerParser.osDetector(UdgerParser.java:478)
	at org.udger.parser.UdgerParser.parseUa(UdgerParser.java:201)
	at org.udger.parser.UdgerParserTest$1.run(UdgerParserTest.java:85)
	at java.lang.Thread.run(Thread.java:748)
```

where certain `ParserDbData` fields are null 

To ensure that all fields will be visible to all threads that have called prepare(), this change adds a volatile boolean flag to serve as a memory barrier. Also adds a test that, at least for me, almost always reproduces the issue.

See the "Fixing Double-Checked Locking using Volatile" section of https://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html for some more context on this issue