### PR TITLE
Bump org.xerial:sqlite-jdbc version to most recent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.21.0</version>
+      <version>3.36.0.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Bumps `org.xerial:sqlite-jdbc` to the most recent version available. Among other benefits, this means there is now M1 support available.

https://github.com/xerial/sqlite-jdbc/commit/e778e16d2350ae1f854ebe2eeaf88cce479f6ee2